### PR TITLE
Ignore vagrant log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ npm-debug.log
 yarn-error.log
 yarn-debug.log
 
+# Ignore vagrant log files
+ubuntu-xenial-16.04-cloudimg-console.log
+
 # Ignore Docker option files
 docker-compose.override.yml
 


### PR DESCRIPTION
While working on another pull request, a log file from vagrant was added with the `git add -A` command since it wasn't included in `.gitignore`, as this may affect other developers using vagrant, it makes sense to add this to the file. Thoughts?